### PR TITLE
Added context with timeout to search, simulated timeout with a test, then refactored by removing the simulation and making the timeout test optional

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 )
 
 // 假資料
@@ -25,17 +27,35 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := SearchResponse{
-		Query: query,
-		Hits: []SearchResult{
-			{ID: 1, Title: "Learning Go"},
-			{ID: 2, Title: "Go Concurrency Patterns"},
-		},
-	}
+	// 建立帶有 timeout 的 context
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+	defer cancel()
 
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		http.Error(w, fmt.Sprintf("encode error: %v", err), http.StatusInternalServerError)
+	// 模擬下游呼叫（例如 Elasticsearch）
+	resultCh := make(chan SearchResponse, 1)
+	go func() {
+		// 假裝需要 3 秒（比 timeout 長）
+		time.Sleep(3 * time.Second)
+		resultCh <- SearchResponse{
+			Query: query,
+			Hits: []SearchResult{
+				{ID: 1, Title: "Learning Go"},
+				{ID: 2, Title: "Go Concurrency Patterns"},
+			},
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		// timeout 或被取消
+		http.Error(w, "search timeout", http.StatusGatewayTimeout)
+		return
+	case resp := <-resultCh:
+		// 正常拿到結果
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, fmt.Sprintf("encode error: %v", err), http.StatusInternalServerError)
+		}
 	}
 }
 

--- a/search_timeout_test.go
+++ b/search_timeout_test.go
@@ -1,3 +1,5 @@
+//go:build slow
+
 package main
 
 import (

--- a/search_timeout_test.go
+++ b/search_timeout_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// 目前的實作：handler 會在 2s 超時、下游模擬 3s -> 必定 504
+func TestSearchHandler_ServerTimeout(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/search?q=golang", nil)
+	rr := httptest.NewRecorder()
+
+	// 直接呼叫目前的 handler
+	searchHandler(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status got %d, want %d", rr.Code, http.StatusGatewayTimeout)
+	}
+	want := "search timeout\n"
+	if rr.Body.String() != want {
+		t.Fatalf("body got %q, want %q", rr.Body.String(), want)
+	}
+}
+
+// 客戶端主動取消（早於 2s timeout），也應拿到 504
+func TestSearchHandler_ClientCancel(t *testing.T) {
+	t.Parallel()
+
+	// 建立一個會在 200ms 取消的 context，包在 request 裡
+	parent := context.Background()
+	ctx, cancel := context.WithTimeout(parent, 200*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/search?q=golang", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	searchHandler(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status got %d, want %d", rr.Code, http.StatusGatewayTimeout)
+	}
+}
+
+// 缺少 q 參數 -> 400
+func TestSearchHandler_BadRequest(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/search", nil)
+	rr := httptest.NewRecorder()
+
+	searchHandler(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status got %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+}


### PR DESCRIPTION
## [bde531a](https://github.com/arealclimber/cloud-native-search/pull/4/commits/bde531abc0ad99091be6b19029ba512b08a54f7b) 加入 context with timeout 並模擬 timeout 情境跟測試
### 加入 context / timeout

```go
// 1) 從當前請求的 context 衍生一個有時限的 ctx
ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
defer cancel()

// 3) 監聽 ctx，時間到（或客戶端中斷）就走這裡
select {
case <-ctx.Done():
    http.Error(w, "search timeout", http.StatusGatewayTimeout)
    return
// ...
}
```

### 模擬下游呼叫（假裝去查 ES/DB）

```go
// 2) 開 goroutine 模擬「呼叫下游」需要時間
resultCh := make(chan SearchResponse, 1)
go func() {
    // 假裝下游很慢：睡 3 秒（故意比 2 秒 timeout 還長）
    time.Sleep(3 * time.Second)
    resultCh <- SearchResponse{
        Query: query,
        Hits: []SearchResult{
            {ID: 1, Title: "Learning Go"},
            {ID: 2, Title: "Go Concurrency Patterns"},
        },
    }
}()

```

### 主流程如何銜接兩者

```go
select {
case <-ctx.Done():           // ←（A）context 超時/取消
    http.Error(w, "search timeout", http.StatusGatewayTimeout)
    return
case resp := <-resultCh:     // ←（B）下游結果回來
    w.Header().Set("Content-Type", "application/json")
    _ = json.NewEncoder(w).Encode(resp)
}

```

### 完整的 main.go

```go
package main

import (
	"context"
	"encoding/json"
	"fmt"
	"log"
	"net/http"
	"time"
)

// 假資料
type SearchResult struct {
	ID    int    `json:"id"`
	Title string `json:"title"`
}

type SearchResponse struct {
	Query string         `json:"query"`
	Hits  []SearchResult `json:"hits"`
}

func searchHandler(w http.ResponseWriter, r *http.Request) {
	query := r.URL.Query().Get("q")
	if query == "" {
		http.Error(w, "missing query parameter: q", http.StatusBadRequest)
		return
	}

	// 建立帶有 timeout 的 context
	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
	defer cancel()

	// 模擬下游呼叫（例如 Elasticsearch）
	resultCh := make(chan SearchResponse, 1)
	go func() {
		// 假裝需要 3 秒（比 timeout 長）
		time.Sleep(3 * time.Second)
		resultCh <- SearchResponse{
			Query: query,
			Hits: []SearchResult{
				{ID: 1, Title: "Learning Go"},
				{ID: 2, Title: "Go Concurrency Patterns"},
			},
		}
	}()

	select {
	case <-ctx.Done():
		// timeout 或被取消
		http.Error(w, "search timeout", http.StatusGatewayTimeout)
		return
	case resp := <-resultCh:
		// 正常拿到結果
		w.Header().Set("Content-Type", "application/json")
		if err := json.NewEncoder(w).Encode(resp); err != nil {
			http.Error(w, fmt.Sprintf("encode error: %v", err), http.StatusInternalServerError)
		}
	}
}

func healthHandler(w http.ResponseWriter, r *http.Request) {
	fmt.Fprintln(w, "ok")
}

func main() {
	cfg := LoadConfig()

	mux := http.NewServeMux()
	mux.HandleFunc("/healthz", healthHandler)
	mux.HandleFunc("/search", searchHandler)

	handler := LoggingMiddleware(RecoveryMiddleware(mux))

	log.Printf("Server listening on %s", cfg.Port)
	if err := http.ListenAndServe(cfg.Port, handler); err != nil {
		log.Fatal(err)
	}
}

```

## [dc9014c](https://github.com/arealclimber/cloud-native-search/pull/4/commits/dc9014c81901f774ea135bc1b60094452c93fc61) 保留 context with timeout，拿掉 timeout 模擬並改 timeout test 為可選的慢測試 